### PR TITLE
Add a deprecation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# xorm
+# [DEPRECATED] xorm
+
+### This repository is deprecated, please use [github.com/grafana/grafana/pkg/util/xorm](https://github.com/grafana/grafana/tree/main/pkg/util/xorm) instead.
 
 [中文](https://gitea.com/xorm/xorm/src/branch/master/README_CN.md)
 


### PR DESCRIPTION
We switched from a xorm fork to a vendored version of it, so let's deprecate the fork